### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Python 2.6-3.5. It has been tested on Windows, Linux, Mac OS X, FreeBSD and
 OpenIndiana.
 
 * `Asyncio documentation <http://docs.python.org/dev/library/asyncio.html>`_
-* `Trollius documentation <http://trollius.readthedocs.org/>`_
+* `Trollius documentation <https://trollius.readthedocs.io/>`_
 * `Trollius project in the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/trollius>`_
 * `Trollius project at Github <https://github.com/haypo/trollius>`_

--- a/doc/asyncio.rst
+++ b/doc/asyncio.rst
@@ -168,7 +168,7 @@ This option is used by the following projects which work on Trollius and asyncio
   module if available, or import ``trollius``.
 * `Tornado <http://www.tornadoweb.org/>`_ supports asyncio and Trollius since
   Tornado 3.2: `tornado.platform.asyncio — Bridge between asyncio and Tornado
-  <http://tornado.readthedocs.org/en/latest/asyncio.html>`_. It tries to import
+  <https://tornado.readthedocs.io/en/latest/asyncio.html>`_. It tries to import
   asyncio or fallback on importing trollius.
 
 Another option is to provide functions returning ``Future`` objects, so the

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -580,7 +580,7 @@ Other changes:
 Trollius changes:
 
 * Add a new Sphinx documentation:
-  http://trollius.readthedocs.org/
+  https://trollius.readthedocs.io/
 * tox: pass posargs to nosetests. Patch contributed by Ian Wienand.
 * Fix support of Python 3.2 and add py32 to tox.ini
 * Merge with Tulip 0.4.1

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -42,7 +42,7 @@ on Python 2. Trollius works on Python 2.7, 3.3 and 3.4. It has been tested on
 Windows, Linux, Mac OS X, FreeBSD and OpenIndiana.
 
 * `Asyncio documentation <http://docs.python.org/dev/library/asyncio.html>`_
-* `Trollius documentation <http://trollius.readthedocs.org/>`_ (this document)
+* `Trollius documentation <https://trollius.readthedocs.io/>`_ (this document)
 * `Trollius project in the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/trollius>`_ (download wheel packages and
   tarballs)

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -91,7 +91,7 @@ Build manually Trollius on Windows
 On Windows, if you cannot use precompiled wheel packages, an extension module
 must be compiled: the ``_overlapped`` module (source code: ``overlapped.c``).
 Read `Compile Python extensions on Windows
-<http://haypo-notes.readthedocs.org/python.html#compile-python-extensions-on-windows>`_
+<https://haypo-notes.readthedocs.io/python.html#compile-python-extensions-on-windows>`_
 to prepare your environment to build the Python extension. Then build the
 extension using::
 

--- a/doc/libraries.rst
+++ b/doc/libraries.rst
@@ -10,7 +10,7 @@ Trollius Libraries
 Libraries compatible with asyncio and trollius
 ==============================================
 
-* `aioeventlet <https://aioeventlet.readthedocs.org/>`_: asyncio API
+* `aioeventlet <https://aioeventlet.readthedocs.io/>`_: asyncio API
   implemented on top of eventlet
 * `aiogevent <https://pypi.python.org/pypi/aiogevent>`_: asyncio API
   implemented on top of gevent
@@ -24,12 +24,12 @@ Libraries compatible with asyncio and trollius
   module if available, or import ``trollius``.
 * `Tornado <http://www.tornadoweb.org/>`_ supports asyncio and Trollius since
   Tornado 3.2: `tornado.platform.asyncio — Bridge between asyncio and Tornado
-  <http://tornado.readthedocs.org/en/latest/asyncio.html>`_. It tries to import
+  <https://tornado.readthedocs.io/en/latest/asyncio.html>`_. It tries to import
   asyncio or fallback on importing trollius.
 
 Specific Ports
 ==============
 
 * `trollius-redis <https://github.com/benjolitz/trollius-redis>`_:
-  A port of `asyncio-redis <http://asyncio-redis.readthedocs.org/>`_ to
+  A port of `asyncio-redis <https://asyncio-redis.readthedocs.io/>`_ to
   trollius


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
