### PR TITLE
Add Appveyor integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,14 @@ environment:
 install:
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
   - python --version
-  - pip install tox wheel
+  - pip install wheel aiotest futures mock six unittest2
   - pip install -e .
-  - python setup.py bdist_wheel
 
-build: off
+build_script:
+  - python setup.py bdist_wheel
 
 test_script:
   - python runtests.py
+
+artifacts:
+  - path: dist/*.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+version: build-{build}-{branch}
+
+environment:
+  matrix:
+    # http://www.appveyor.com/docs/installed-software#python lists available
+    # versions
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
+
+install:
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - python --version
+  - pip install tox wheel
+  - pip install -e .
+  - python setup.py bdist_wheel
+
+build: off
+
+test_script:
+  - python runtests.py


### PR DESCRIPTION
Appveyor is a free (for FOSS projects) hosted continuous integration platform
for Windows.

To make use of it, you'll have to log in at https://ci.appveyor.com/ (you can
use your existing GitHub account), click the "NEW PROJECT" button, and add the
trollus repository.

Eventually you can set it up to build binary wheels and upload them to PyPI for
you (see https://github.com/zopefoundation/zope.interface/blob/master/appveyor.yml#L27
for an example).  This would make https://github.com/haypo/trollius/issues/12#issuecomment-247097395
less painful.
