### PR TITLE
Fix SelectSelector to be compatible with monkey_patch

### DIFF
--- a/trollius/selectors.py
+++ b/trollius/selectors.py
@@ -309,7 +309,8 @@ class SelectSelector(_BaseSelectorImpl):
             r, w, x = select.select(r, w, w, timeout)
             return r, w + x, []
     else:
-        _select = select.select
+        def _select(self, r, w, x, timeout=None):
+            return select.select(r, w, x, timeout)
 
     def select(self, timeout=None):
         timeout = None if timeout is None else max(timeout, 0)


### PR DESCRIPTION
When using eventlet.monkey_patch(), it disables all the Selectors but
the SelectSelector. Another thing it does is modify how the constructor
handles the class methods.
The way the SelectSelector handles the _select function is incompatible
with that code.
We should have a bound method calling the select function (as is done
for the Win32) in order to fix this compatibility issue.